### PR TITLE
Default for group by is empty string, not null

### DIFF
--- a/tests/test_counter_block.py
+++ b/tests/test_counter_block.py
@@ -169,7 +169,7 @@ class TestCounter(NIOBlockTestCase):
             Signal({'foo': 'baz'}),
             Signal({'qux': 'ly'})
         ])
-        self.assertEqual(block._cumulative_count['null'], 1)
+        self.assertEqual(block._cumulative_count[''], 1)
         self.assertEqual(block._cumulative_count['bar'], 1)
         self.assertEqual(block._cumulative_count['baz'], 1)
         e.wait(2)


### PR DESCRIPTION
Fixes the unit tests with the new group by mixin