### PR TITLE
Add ResettableCounter block

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,41 @@ Output Signal Attributes
 -   `cumulative_count`: Number of signals since reset.
 -   `group`: The group that the counts relate to as defined by `group_by`.
 
+ResettableCounter
+=======
+Basically the same thing as the `Counter` block but with an additional input that allows you to reset a group's cumulative count with an incoming signal. The `Counter` block includes a `reset` command that lets you reset all cumulative counts, but sometimes it is necessary to reset a count within a service.
+
+The Counter block counts the number of signals that pass through the block. It outputs the `count`, which is the length of each incoming list of signals processed by the block, and a `cumulative_count` which is the total number of signals (a sum of all the previous `count`s) that have been processed by the block since the last reset.
+
+Properties
+----------
+- **backup_interval**: An interval of time that specifies how often persisted data is saved.
+- **enrich**: If checked (true), the attributes of the incoming signal will be excluded from the outgoing signal. If unchecked (false), the attributes of the incoming signal will be included in the outgoing signal.
+- **group_by**: The signal attribute on the incoming signal whose values will be used to define groups on the outgoing signal.
+- **load_from_persistence**: If `True`, the block’s state will be saved when the block is stopped, and reloaded once the block is restarted.
+- **reset_info**: If **resetting** is `True`, the *cumulative_count* output will reset after the specified interval or time. When **scheme** is set to `INTERVAL` then *cumulative_count* will reset every **interval**. When **scheme** is set to `CRON` then *cumulative_count* will reset at every **at** (in UTC time).
+
+Inputs
+------
+- **count**: Any list of signals that should be counted
+- **reset**: Signals to trigger a reset of the cumulative count. The signals must have the necessary group information on them in order to reset the proper group.
+
+Outputs
+-------
+- **default**: Signal including the count, cumulative count, and group. On reset of a group a signal will be notified with a `count` of `0` and the `cumulative_count` having the cumulative count of the group at the time of reset.
+
+Commands
+--------
+- **groups**: Returns a list of the block’s current signal groupings.
+- **reset**: Notifies a signal with `count` equal to 0 and `cumulative_count` equal to the cumulative count. Cumulative count is then set to 0.
+
+Dependencies
+------------
+[GroupBy Block Supplement](https://github.com/nio-blocks/block_supplements/tree/master/group_by)
+
+Output Signal Attributes
+------------------------
+-   **count**: Number of signals that were sent into the signal.
+-   **cumulative_count**: Number of signals since reset.
+-   **group**: The group that the counts relate to as defined by `group_by`.
+

--- a/reset_counter_block.py
+++ b/reset_counter_block.py
@@ -1,0 +1,28 @@
+from nio.block import input
+from nio.properties import VersionProperty
+
+from .counter_block import Counter
+
+
+@input('count', label='Count', default=True, order=1)
+@input('reset', label='Reset', order=2)
+class ResettableCounter(Counter):
+
+    """ The same as the counter block but with an input to reset a
+    cumulative count """
+    version = VersionProperty("0.1.0")
+
+    def process_signals(self, signals, input_id='count'):
+        if input_id == 'reset':
+            self.notify_signals(self.for_each_group(
+                self.reset_group_from_signals, signals))
+        else:
+            super().process_signals(signals)
+
+    def reset_group_from_signals(self, signals, key):
+        """ Reset the groups inlcuded in the list of incoming signals.
+
+        A method that takes signals as the first argument for use in
+        the group by mixin's for_each_group method.
+        """
+        return self.reset_group(key)

--- a/tests/test_reset_counter_block.py
+++ b/tests/test_reset_counter_block.py
@@ -1,0 +1,42 @@
+from nio import Signal
+from nio.testing.block_test_case import NIOBlockTestCase
+
+from ..reset_counter_block import ResettableCounter
+
+
+class TestResetCounter(NIOBlockTestCase):
+
+    def test_reset_count(self):
+        block = ResettableCounter()
+        self.configure_block(block, {})
+        block.start()
+        block.process_signals([Signal()])
+        block.process_signals([Signal()])
+        block.process_signals([Signal()])
+        self.assertEqual(block._cumulative_count[None], 3)
+        self.assert_num_signals_notified(3)
+        block.process_signals([Signal()], input_id='reset')
+        block.process_signals([Signal()])
+        block.process_signals([Signal()])
+        self.assert_num_signals_notified(6)
+        self.assertEqual(block._cumulative_count[None], 2)
+        block.stop()
+
+    def test_reset_count_groups(self):
+        block = ResettableCounter()
+        self.configure_block(block, {
+            "group_by": "{{ $group_key }}",
+        })
+        block.start()
+        block.process_signals([Signal({'group_key': 'A'})])
+        block.process_signals([Signal({'group_key': 'B'})])
+        block.process_signals([Signal({'group_key': 'A'})])
+        self.assertEqual(block._cumulative_count['A'], 2)
+        self.assertEqual(block._cumulative_count['B'], 1)
+        self.assert_num_signals_notified(3)
+        block.process_signals([Signal({'group_key': 'A'})], input_id='reset')
+        self.assertEqual(block._cumulative_count['A'], 0)
+        self.assertEqual(block._cumulative_count['B'], 1)
+        # Only one reset signal even through there's two groups
+        self.assert_num_signals_notified(4)
+        block.stop()


### PR DESCRIPTION
This adds a block that has a reset input to reset the cumulative count for a group.

This block still needs its docs and release stuff rolled out into the docs folder, I'll tackle that in another PR.