### PR TITLE
Remove reset groups from _cumulative_count

### DIFF
--- a/counter_block.py
+++ b/counter_block.py
@@ -208,7 +208,8 @@ class Counter(EnrichSignals, Persistence, GroupBy, Block):
             "group": key
         })
 
-        # set the cumulative count, last reset, and write both to disk
-        self._cumulative_count[key] = 0
+        # remove the group from cumulative count and update _last_reset
+        del self._cumulative_count[key]
+        self._last_reset = datetime.utcnow()
         # finally, send the signal with the counts at reset time
         return [signal]

--- a/counter_block.py
+++ b/counter_block.py
@@ -211,7 +211,5 @@ class Counter(EnrichSignals, Persistence, GroupBy, Block):
         # remove the group from cumulative count and update _last_reset
         del self._cumulative_count[key]
         self._last_reset = datetime.utcnow()
-        # remove this group from _groups
-        self._groups.remove(key)
         # finally, send the signal with the counts at reset time
         return [signal]

--- a/counter_block.py
+++ b/counter_block.py
@@ -211,5 +211,7 @@ class Counter(EnrichSignals, Persistence, GroupBy, Block):
         # remove the group from cumulative count and update _last_reset
         del self._cumulative_count[key]
         self._last_reset = datetime.utcnow()
+        # remove this group from _groups
+        self._groups.remove(key)
         # finally, send the signal with the counts at reset time
         return [signal]

--- a/counter_block.py
+++ b/counter_block.py
@@ -208,8 +208,7 @@ class Counter(EnrichSignals, Persistence, GroupBy, Block):
             "group": key
         })
 
-        # remove the group from cumulative count and update _last_reset
+        # remove the group from cumulative count
         del self._cumulative_count[key]
-        self._last_reset = datetime.utcnow()
         # finally, send the signal with the counts at reset time
         return [signal]

--- a/counter_block.py
+++ b/counter_block.py
@@ -52,9 +52,13 @@ class Counter(EnrichSignals, Persistence, GroupBy, Block):
                 be reset. Corresponds to INTERVAL mode.
 
     """
+    clear_on_reset = BoolProperty(
+        title="Clear Groups on Reset",
+        default=False,
+        advanced=True)
     reset_info = ObjectProperty(ResetInfo, title='Reset Info',
                                 default=ResetInfo())
-    version = VersionProperty("0.1.1")
+    version = VersionProperty("0.2.0")
 
     def __init__(self):
         super().__init__()
@@ -207,8 +211,12 @@ class Counter(EnrichSignals, Persistence, GroupBy, Block):
             "cumulative_count": self._cumulative_count[key],
             "group": key
         })
-
-        # remove the group from cumulative count
-        del self._cumulative_count[key]
+        if self.clear_on_reset():
+            # remove from _groups, _cumulative_count
+            del self._cumulative_count[key]
+            self._groups.remove(key)
+        else:
+            # reset count
+            self._cumulative_count[key] = 0
         # finally, send the signal with the counts at reset time
         return [signal]

--- a/docs/counter.md
+++ b/docs/counter.md
@@ -30,4 +30,4 @@ Output Signal Attributes
 Commands
 --------
 - **groups**: Returns a list of the block’s current signal groupings.
-- **reset**: Notifies a signal with `count` equal to 0 and `cumulative_count` equal to the cumulative count.
+- **reset**: Notifies a signal with `count` equal to 0 and `cumulative_count` equal to the cumulative count. Cumulative count is then set to 0.

--- a/docs/counter.md
+++ b/docs/counter.md
@@ -30,4 +30,4 @@ Output Signal Attributes
 Commands
 --------
 - **groups**: Returns a list of the block’s current signal groupings.
-- **reset**: Notifies a signal with `count` equal to 0 and `cumulative_count` equal to the cumulative count.
+- **reset**: Notifies a signal with `count` equal to 0 and `cumulative_count` equal to the cumulative count. The set of processed groups will be cleared.

--- a/docs/counter.md
+++ b/docs/counter.md
@@ -8,7 +8,7 @@ Properties
 
 Advanced Properties
 -------------------
-- **Backup Interval**: An interval of time that specifies how often persisted data is saved.
+- **Clear Groups on Reset**: If `True`, when reset `_groups` and `_cumulative_count` will be emptied.
 - **Exclude Existing**: If checked (true), the attributes of the incoming signal will be excluded from the outgoing signal. If unchecked (false), the attributes of the incoming signal will be included in the outgoing signal.
 - **Group By**: The signal attribute on the incoming signal whose values will be used to define groups on the outgoing signal.
 - **Load From Persistence**: If `True`, the block’s state will be saved when the block is stopped, and reloaded once the block is restarted.

--- a/docs/counter.md
+++ b/docs/counter.md
@@ -30,4 +30,4 @@ Output Signal Attributes
 Commands
 --------
 - **groups**: Returns a list of the block’s current signal groupings.
-- **reset**: Notifies a signal with `count` equal to 0 and `cumulative_count` equal to the cumulative count. Cumulative count is then set to 0.
+- **reset**: Notifies a signal with `count` equal to 0 and `cumulative_count` equal to the cumulative count.

--- a/docs/counter.md
+++ b/docs/counter.md
@@ -30,4 +30,4 @@ Output Signal Attributes
 Commands
 --------
 - **groups**: Returns a list of the block’s current signal groupings.
-- **reset**: Notifies a signal with `count` equal to 0 and `cumulative_count` equal to the cumulative count. The set of processed groups will be cleared.
+- **reset**: Notifies a signal with `count` equal to 0 and `cumulative_count` equal to the cumulative count.

--- a/docs/numeric_counter.md
+++ b/docs/numeric_counter.md
@@ -10,7 +10,7 @@ Properties
 
 Advanced Properties
 -------------------
-- **Backup Interval**: An interval of time that specifies how often persisted data is saved.
+- **Clear Groups on Reset**: If `True`, when reset `_groups` and `_cumulative_count` will be emptied.
 - **Exclude Existing**: If checked (true), the attributes of the incoming signal will be excluded from the outgoing signal. If unchecked (false), the attributes of the incoming signal will be included in the outgoing signal.
 - **Group By**: The signal attribute on the incoming signal whose values will be used to define groups on the outgoing signal.
 - **Load From Persistence**: If `True`, the block’s state will be saved when the block is stopped, and reloaded once the block is restarted.

--- a/docs/resettable_counter.md
+++ b/docs/resettable_counter.md
@@ -10,7 +10,7 @@ Properties
 
 Advanced Properties
 -------------------
-- **Backup Interval**: An interval of time that specifies how often persisted data is saved.
+- **Clear Groups on Reset**: If `True`, when reset `_groups` and `_cumulative_count` will be emptied.
 - **Exclude Existing**: If checked (true), the attributes of the incoming signal will be excluded from the outgoing signal. If unchecked (false), the attributes of the incoming signal will be included in the outgoing signal.
 - **Group By**: The signal attribute on the incoming signal whose values will be used to define groups on the outgoing signal.
 - **Load From Persistence**: If `True`, the block’s state will be saved when the block is stopped, and reloaded once the block is restarted.

--- a/docs/resettable_counter.md
+++ b/docs/resettable_counter.md
@@ -33,4 +33,4 @@ Output Signal Attributes
 Commands
 --------
 - **groups**: Returns a list of the block’s current signal groupings.
-- **reset**: Notifies a signal with `count` equal to 0 and `cumulative_count` equal to the cumulative count. The set of processed groups will be cleared.
+- **reset**: Notifies a signal with `count` equal to 0 and `cumulative_count` equal to the cumulative count. Cumulative count is then set to 0.

--- a/docs/resettable_counter.md
+++ b/docs/resettable_counter.md
@@ -33,4 +33,4 @@ Output Signal Attributes
 Commands
 --------
 - **groups**: Returns a list of the block’s current signal groupings.
-- **reset**: Notifies a signal with `count` equal to 0 and `cumulative_count` equal to the cumulative count. Cumulative count is then set to 0.
+- **reset**: Notifies a signal with `count` equal to 0 and `cumulative_count` equal to the cumulative count. The set of processed groups will be cleared.

--- a/docs/tally_counter.md
+++ b/docs/tally_counter.md
@@ -30,4 +30,4 @@ Output Signal Attributes
 Commands
 --------
 - **groups**: Returns a list of the block’s current signal groupings.
-- **reset**: Notifies a signal with `count` equal to 0 and `cumulative_count` equal to the cumulative count. The group(s) reset are removed from `tally`
+- **reset**: Notifies a signal with `count` equal to 0 and `cumulative_count` equal to the cumulative count. The set of processed groups will be cleared.

--- a/docs/tally_counter.md
+++ b/docs/tally_counter.md
@@ -30,4 +30,4 @@ Output Signal Attributes
 Commands
 --------
 - **groups**: Returns a list of the block’s current signal groupings.
-- **reset**: Notifies a signal with `count` equal to 0 and `cumulative_count` equal to the cumulative count. The set of processed groups will be cleared.
+- **reset**: Notifies a signal with `count` equal to 0 and `cumulative_count` equal to the cumulative count. The group(s) reset are removed from `tally`

--- a/docs/tally_counter.md
+++ b/docs/tally_counter.md
@@ -8,7 +8,7 @@ Properties
 
 Advanced Properties
 -------------------
-- **Backup Interval**: An interval of time that specifies how often persisted data is saved.
+- **Clear Groups on Reset**: If `True`, when reset `_groups` and `_cumulative_count` will be emptied.
 - **Exclude Existing**: If checked (true), the attributes of the incoming signal will be excluded from the outgoing signal. If unchecked (false), the attributes of the incoming signal will be included in the outgoing signal.
 - **Group By**: The signal attribute on the incoming signal whose values will be used to define groups on the outgoing signal.
 - **Load From Persistence**: If `True`, the block’s state will be saved when the block is stopped, and reloaded once the block is restarted.

--- a/docs/tally_counter.md
+++ b/docs/tally_counter.md
@@ -19,7 +19,7 @@ Inputs
 
 Outputs
 -------
-- **default**: Signal including the count, cumulative count, and group.
+- **default**: Signal including the `count`, `group`, and `tally`.
 
 Output Signal Attributes
 ------------------------
@@ -30,4 +30,4 @@ Output Signal Attributes
 Commands
 --------
 - **groups**: Returns a list of the block’s current signal groupings.
-- **reset**: Notifies a signal with `count` equal to 0 and `cumulative_count` equal to the cumulative count. Cumulative count is then set to 0.
+- **reset**: Notifies a signal with `count` equal to 0 and `cumulative_count` equal to the cumulative count. The group(s) reset are removed from `tally`

--- a/numeric_counter_block.py
+++ b/numeric_counter_block.py
@@ -6,7 +6,7 @@ from .counter_block import Counter
 
 class NumericCounter(Counter):
 
-    version = VersionProperty("0.1.1")
+    version = VersionProperty("0.2.0")
     count_expr = IntProperty(title='Count', default='{{$count}}')
     send_zeroes = BoolProperty(title='Send Zero Counts', default=True)
 

--- a/reset_counter_block.py
+++ b/reset_counter_block.py
@@ -10,7 +10,7 @@ class ResettableCounter(Counter):
 
     """ The same as the counter block but with an input to reset a
     cumulative count """
-    version = VersionProperty("0.1.0")
+    version = VersionProperty("0.2.0")
 
     def process_signals(self, signals, input_id='count'):
         if input_id == 'reset':

--- a/tally_counter_block.py
+++ b/tally_counter_block.py
@@ -13,7 +13,7 @@ class TallyCounter(Counter):
     each key is the `cumulative_count` for that `group`.
 
     """
-    version = VersionProperty("0.0.1")
+    version = VersionProperty("0.1.0")
 
     def process_group(self, signals, key):
         """ Executed on each group of incoming signal objects.

--- a/tests/test_counter_block.py
+++ b/tests/test_counter_block.py
@@ -85,7 +85,6 @@ class TestCounter(NIOBlockTestCase):
         self.assertEqual(block._cumulative_count[None], 1)
         block.reset()
         self.assertFalse(block._cumulative_count)
-        self.assertFalse(block._groups)
         block.stop()
 
     def test_interval_reset(self):
@@ -104,7 +103,6 @@ class TestCounter(NIOBlockTestCase):
         block.process_signals([Signal(), Signal()])
         e.wait(2)
         self.assertFalse(block._cumulative_count)
-        self.assertFalse(block._groups)
         block.stop()
 
     def test_cron_sched(self):
@@ -131,7 +129,6 @@ class TestCounter(NIOBlockTestCase):
         self.assertEqual(block._cumulative_count[None], 1)
         e.wait(1.25)
         self.assertFalse(block._cumulative_count)
-        self.assertFalse(block._groups)
 
     def test_cron_missed_reset(self):
         now = datetime.utcnow()
@@ -181,7 +178,6 @@ class TestCounter(NIOBlockTestCase):
         self.assertEqual(block._cumulative_count['baz'], 1)
         e.wait(2)
         self.assertFalse(block._cumulative_count)
-        self.assertFalse(block._groups)
         block.stop()
 
     def test_persistence(self):

--- a/tests/test_counter_block.py
+++ b/tests/test_counter_block.py
@@ -85,6 +85,7 @@ class TestCounter(NIOBlockTestCase):
         self.assertEqual(block._cumulative_count[None], 1)
         block.reset()
         self.assertFalse(block._cumulative_count)
+        self.assertFalse(block._groups)
         block.stop()
 
     def test_interval_reset(self):
@@ -103,6 +104,7 @@ class TestCounter(NIOBlockTestCase):
         block.process_signals([Signal(), Signal()])
         e.wait(2)
         self.assertFalse(block._cumulative_count)
+        self.assertFalse(block._groups)
         block.stop()
 
     def test_cron_sched(self):
@@ -129,6 +131,7 @@ class TestCounter(NIOBlockTestCase):
         self.assertEqual(block._cumulative_count[None], 1)
         e.wait(1.25)
         self.assertFalse(block._cumulative_count)
+        self.assertFalse(block._groups)
 
     def test_cron_missed_reset(self):
         now = datetime.utcnow()
@@ -178,6 +181,7 @@ class TestCounter(NIOBlockTestCase):
         self.assertEqual(block._cumulative_count['baz'], 1)
         e.wait(2)
         self.assertFalse(block._cumulative_count)
+        self.assertFalse(block._groups)
         block.stop()
 
     def test_persistence(self):

--- a/tests/test_counter_block.py
+++ b/tests/test_counter_block.py
@@ -83,6 +83,8 @@ class TestCounter(NIOBlockTestCase):
         block.reset()
         block.process_signals([Signal()])
         self.assertEqual(block._cumulative_count[None], 1)
+        block.reset()
+        self.assertFalse(block._cumulative_count)
         block.stop()
 
     def test_interval_reset(self):
@@ -100,7 +102,7 @@ class TestCounter(NIOBlockTestCase):
         block.start()
         block.process_signals([Signal(), Signal()])
         e.wait(2)
-        self.assertEqual(block._cumulative_count[None], 0)
+        self.assertFalse(block._cumulative_count)
         block.stop()
 
     def test_cron_sched(self):
@@ -126,7 +128,7 @@ class TestCounter(NIOBlockTestCase):
         block.process_signals([Signal()])
         self.assertEqual(block._cumulative_count[None], 1)
         e.wait(1.25)
-        self.assertEqual(block._cumulative_count[None], 0)
+        self.assertFalse(block._cumulative_count)
 
     def test_cron_missed_reset(self):
         now = datetime.utcnow()
@@ -175,8 +177,7 @@ class TestCounter(NIOBlockTestCase):
         self.assertEqual(block._cumulative_count['bar'], 1)
         self.assertEqual(block._cumulative_count['baz'], 1)
         e.wait(2)
-        for k in block._cumulative_count:
-            self.assertEqual(block._cumulative_count[k], 0)
+        self.assertFalse(block._cumulative_count)
         block.stop()
 
     def test_persistence(self):

--- a/tests/test_reset_counter_block.py
+++ b/tests/test_reset_counter_block.py
@@ -36,7 +36,6 @@ class TestResetCounter(NIOBlockTestCase):
         self.assert_num_signals_notified(3)
         block.process_signals([Signal({'group_key': 'A'})], input_id='reset')
         self.assertFalse('A' in block._cumulative_count.keys())
-        self.assertFalse('A' in block._groups)
         self.assertEqual(block._cumulative_count['B'], 1)
         # Only one reset signal even through there's two groups
         self.assert_num_signals_notified(4)

--- a/tests/test_reset_counter_block.py
+++ b/tests/test_reset_counter_block.py
@@ -36,6 +36,7 @@ class TestResetCounter(NIOBlockTestCase):
         self.assert_num_signals_notified(3)
         block.process_signals([Signal({'group_key': 'A'})], input_id='reset')
         self.assertFalse('A' in block._cumulative_count.keys())
+        self.assertFalse('A' in block._groups)
         self.assertEqual(block._cumulative_count['B'], 1)
         # Only one reset signal even through there's two groups
         self.assert_num_signals_notified(4)

--- a/tests/test_reset_counter_block.py
+++ b/tests/test_reset_counter_block.py
@@ -35,7 +35,7 @@ class TestResetCounter(NIOBlockTestCase):
         self.assertEqual(block._cumulative_count['B'], 1)
         self.assert_num_signals_notified(3)
         block.process_signals([Signal({'group_key': 'A'})], input_id='reset')
-        self.assertFalse('A' in block._cumulative_count.keys())
+        self.assertEqual(block._cumulative_count['A'], 0)
         self.assertEqual(block._cumulative_count['B'], 1)
         # Only one reset signal even through there's two groups
         self.assert_num_signals_notified(4)

--- a/tests/test_reset_counter_block.py
+++ b/tests/test_reset_counter_block.py
@@ -35,7 +35,7 @@ class TestResetCounter(NIOBlockTestCase):
         self.assertEqual(block._cumulative_count['B'], 1)
         self.assert_num_signals_notified(3)
         block.process_signals([Signal({'group_key': 'A'})], input_id='reset')
-        self.assertEqual(block._cumulative_count['A'], 0)
+        self.assertFalse('A' in block._cumulative_count.keys())
         self.assertEqual(block._cumulative_count['B'], 1)
         # Only one reset signal even through there's two groups
         self.assert_num_signals_notified(4)

--- a/tests/test_tally_counter_block.py
+++ b/tests/test_tally_counter_block.py
@@ -7,7 +7,7 @@ from ..tally_counter_block import TallyCounter
 class TestCounter(NIOBlockTestCase):
 
     def test_tally(self):
-        """ Test that all groups are notified inside `tally` """
+        """ All groups are notified inside `tally` """
         blk = TallyCounter()
         self.configure_block(blk, {
             'group_by': '{{ $foo }}',
@@ -48,4 +48,30 @@ class TestCounter(NIOBlockTestCase):
                     'baz': 1,
                 },
             }),
+        ])
+
+    def test_reset(self):
+        """ Calling `reset` removes groups from `tally` """
+        blk = TallyCounter()
+        self.configure_block(blk, {
+            'group_by': '{{ $foo }}',
+        })
+        blk.start()
+
+        blk.process_signals([
+            Signal({'foo': 'bar'}),
+            Signal({'foo': 'baz'}),
+        ])
+        blk.reset()
+        blk.process_signals([
+            Signal({'foo': 'bar'}),
+        ])
+        self.assert_last_signal_list_notified([
+            Signal({
+                'count': 1,
+                'group': 'bar',
+                'tally': {
+                    'bar': 1,
+                },
+            })
         ])

--- a/tests/test_tally_counter_block.py
+++ b/tests/test_tally_counter_block.py
@@ -37,7 +37,7 @@ class TestCounter(NIOBlockTestCase):
                 'foo': 'baz',
             }),
         ])
-        self.assert_last_signal_list_notified([
+        self.assert_signal_notified(
             Signal({
                 'count': 1,
                 'group': 'bar',
@@ -45,7 +45,8 @@ class TestCounter(NIOBlockTestCase):
                     'bar': 2,
                     'baz': 1,
                 },
-            }),
+            }))
+        self.assert_signal_notified(
             Signal({
                 'count': 1,
                 'group': 'baz',
@@ -53,5 +54,4 @@ class TestCounter(NIOBlockTestCase):
                     'bar': 2,
                     'baz': 1,
                 },
-            }),
-        ])
+            }))

--- a/tests/test_tally_counter_block.py
+++ b/tests/test_tally_counter_block.py
@@ -15,7 +15,9 @@ class TestCounter(NIOBlockTestCase):
         blk.start()
 
         blk.process_signals([
-            Signal({'foo': 'bar'}),
+            Signal({
+                'foo': 'bar',
+            }),
         ])
         self.assert_last_signal_list_notified([
             Signal({
@@ -28,8 +30,12 @@ class TestCounter(NIOBlockTestCase):
         ])
 
         blk.process_signals([
-            Signal({'foo': 'bar'}),
-            Signal({'foo': 'baz'}),
+            Signal({
+                'foo': 'bar',
+            }),
+            Signal({
+                'foo': 'baz',
+            }),
         ])
         self.assert_last_signal_list_notified([
             Signal({

--- a/tests/test_tally_counter_block.py
+++ b/tests/test_tally_counter_block.py
@@ -7,7 +7,7 @@ from ..tally_counter_block import TallyCounter
 class TestCounter(NIOBlockTestCase):
 
     def test_tally(self):
-        """ All groups are notified inside `tally` """
+        """ Test that all groups are notified inside `tally` """
         blk = TallyCounter()
         self.configure_block(blk, {
             'group_by': '{{ $foo }}',
@@ -48,30 +48,4 @@ class TestCounter(NIOBlockTestCase):
                     'baz': 1,
                 },
             }),
-        ])
-
-    def test_reset(self):
-        """ Calling `reset` removes groups from `tally` """
-        blk = TallyCounter()
-        self.configure_block(blk, {
-            'group_by': '{{ $foo }}',
-        })
-        blk.start()
-
-        blk.process_signals([
-            Signal({'foo': 'bar'}),
-            Signal({'foo': 'baz'}),
-        ])
-        blk.reset()
-        blk.process_signals([
-            Signal({'foo': 'bar'}),
-        ])
-        self.assert_last_signal_list_notified([
-            Signal({
-                'count': 1,
-                'group': 'bar',
-                'tally': {
-                    'bar': 1,
-                },
-            })
         ])


### PR DESCRIPTION
QUESTION: Should resetting a counter also remove the `group` from `_groups`? I think that it should, unless I'm missing something: after sending a `reset` command, I expect that those group(s) should _not_ appear in the response to a `groups` command.

EDIT: `reset` does not take a `group` param, so in fact the questions is "should `_groups` be cleared on `reset()`?"

UPDATE: `e2515b4` implements this.